### PR TITLE
Limit class management to admins

### DIFF
--- a/firebase-auth.js
+++ b/firebase-auth.js
@@ -176,8 +176,9 @@ function showApp() {
     
     // KOMPLETT ALLE Tabs verstecken und Buttons deaktivieren
     const allTabs = [
-        'newsTab', 'themenTab', 'gruppenTab', 'lehrerTab', 
-        'datenTab', 'bewertenTab', 'vorlagenTab', 'uebersichtTab', 'adminvorlagenTab'
+        'newsTab', 'themenTab', 'gruppenTab', 'lehrerTab',
+        'datenTab', 'bewertenTab', 'vorlagenTab', 'uebersichtTab',
+        'adminvorlagenTab', 'klassenTab'
     ];
     
     allTabs.forEach(tabId => {
@@ -203,6 +204,7 @@ function showApp() {
         document.getElementById('lehrerTab').style.display = 'block';
         document.getElementById('datenTab').style.display = 'block';
         document.getElementById('adminvorlagenTab').style.display = 'block';
+        document.getElementById('klassenTab').style.display = 'block';
         
         // Ersten sichtbaren Tab aktivieren
         document.getElementById('newsTab').classList.add('active');
@@ -258,8 +260,9 @@ async function firebaseLogout() {
 // Alle Tabs verstecken
 function hideAllTabs() {
     const allTabs = [
-        'newsTab', 'themenTab', 'gruppenTab', 'lehrerTab', 
-        'datenTab', 'bewertenTab', 'vorlagenTab', 'uebersichtTab', 'adminvorlagenTab'
+        'newsTab', 'themenTab', 'gruppenTab', 'lehrerTab',
+        'datenTab', 'bewertenTab', 'vorlagenTab', 'uebersichtTab',
+        'adminvorlagenTab', 'klassenTab'
     ];
     
     allTabs.forEach(tabId => {

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
                 <button class="tab-btn active" onclick="openTab('news')" id="newsTab">News</button>
                 <button class="tab-btn" onclick="openTab('themen')" id="themenTab">Themen</button>
                 <button class="tab-btn" onclick="openTab('gruppen')" id="gruppenTab">Gruppen erstellen</button>
-                <button class="tab-btn" onclick="openTab('klassen')" id="klassenTab">Klassen verwalten</button>
+                <button class="tab-btn" onclick="openTab('klassen')" id="klassenTab" style="display:none;">Klassen verwalten</button>
                 <button class="tab-btn" onclick="openTab('lehrer')" id="lehrerTab">Lehrer verwalten</button>
                 <button class="tab-btn" onclick="openTab('daten')" id="datenTab">Datenverwaltung</button>
                 <button class="tab-btn" onclick="openTab('bewerten')" id="bewertenTab">Schüler bewerten</button>


### PR DESCRIPTION
## Summary
- hide the Klassen tab by default
- display Klassen tab only for admins
- protect `openTab('klassen')` with an admin check and load classes

## Testing
- `node --check firebase-main.js`
- `node --check firebase-auth.js`


------
https://chatgpt.com/codex/tasks/task_e_684345860588832cabf5061445619719