### PR TITLE
Limit class management to admins

### DIFF
--- a/firebase-auth.js
+++ b/firebase-auth.js
@@ -176,8 +176,9 @@ function showApp() {
     
     // KOMPLETT ALLE Tabs verstecken und Buttons deaktivieren
     const allTabs = [
-        'newsTab', 'themenTab', 'gruppenTab', 'lehrerTab', 
-        'datenTab', 'bewertenTab', 'vorlagenTab', 'uebersichtTab', 'adminvorlagenTab'
+        'newsTab', 'themenTab', 'gruppenTab', 'lehrerTab',
+        'datenTab', 'bewertenTab', 'vorlagenTab', 'uebersichtTab',
+        'adminvorlagenTab', 'klassenTab'
     ];
     
     allTabs.forEach(tabId => {
@@ -203,6 +204,7 @@ function showApp() {
         document.getElementById('lehrerTab').style.display = 'block';
         document.getElementById('datenTab').style.display = 'block';
         document.getElementById('adminvorlagenTab').style.display = 'block';
+        document.getElementById('klassenTab').style.display = 'block';
         
         // Ersten sichtbaren Tab aktivieren
         document.getElementById('newsTab').classList.add('active');
@@ -258,8 +260,9 @@ async function firebaseLogout() {
 // Alle Tabs verstecken
 function hideAllTabs() {
     const allTabs = [
-        'newsTab', 'themenTab', 'gruppenTab', 'lehrerTab', 
-        'datenTab', 'bewertenTab', 'vorlagenTab', 'uebersichtTab', 'adminvorlagenTab'
+        'newsTab', 'themenTab', 'gruppenTab', 'lehrerTab',
+        'datenTab', 'bewertenTab', 'vorlagenTab', 'uebersichtTab',
+        'adminvorlagenTab', 'klassenTab'
     ];
     
     allTabs.forEach(tabId => {

--- a/firebase-main.js
+++ b/firebase-main.js
@@ -7,6 +7,7 @@ let dataCache = {
     faecher: {},
     bewertungsCheckpoints: {},
     themen: {},
+    klassen: {},
     gruppen: {},
     bewertungen: {},
     vorlagen: {},
@@ -51,6 +52,7 @@ function initializeDataCache() {
         faecher: {},
         bewertungsCheckpoints: {},
         themen: {},
+        klassen: {},
         gruppen: {},
         bewertungen: {},
         vorlagen: {},
@@ -71,9 +73,16 @@ async function loadSystemData() {
         // Config laden
         await loadConfig();
         
+
+        // Benutzer laden
+        await loadUsers();
+
         // Fächer laden
         await loadFaecher();
-        
+
+        // Klassen laden
+        await loadKlassen();
+
         // Bewertungs-Checkpoints laden
         await loadBewertungsCheckpoints();
         
@@ -349,6 +358,44 @@ async function loadStaerkenFormulierungen() {
     }
 }
 
+// Benutzer laden
+async function loadUsers() {
+    try {
+        const usersRef = window.firebaseDB.ref(window.database, 'users');
+        const snapshot = await window.firebaseDB.get(usersRef);
+
+        if (snapshot.exists()) {
+            dataCache.users = snapshot.val();
+            console.log('✅ Benutzer geladen:', Object.keys(dataCache.users).length);
+        } else {
+            dataCache.users = {};
+            console.log('ℹ️ Keine Benutzer gefunden');
+        }
+    } catch (error) {
+        console.error('❌ Fehler beim Laden der Benutzer:', error);
+        dataCache.users = {};
+    }
+}
+
+// Klassen laden
+async function loadKlassen() {
+    try {
+        const klassenRef = window.firebaseDB.ref(window.database, 'klassen');
+        const snapshot = await window.firebaseDB.get(klassenRef);
+
+        if (snapshot.exists()) {
+            dataCache.klassen = Object.values(snapshot.val());
+            console.log('✅ Klassen geladen:', dataCache.klassen.length);
+        } else {
+            dataCache.klassen = [];
+            console.log('ℹ️ Keine Klassen gefunden');
+        }
+    } catch (error) {
+        console.error('❌ Fehler beim Laden der Klassen:', error);
+        dataCache.klassen = [];
+    }
+}
+
 // === REALTIME LISTENERS ===
 
 // Realtime Listeners einrichten
@@ -388,6 +435,36 @@ function setupRealtimeListeners() {
                 console.log('🔄 Gruppen Update erhalten');
                 if (typeof loadGruppen === 'function') {
                     loadGruppen();
+                }
+            }
+        });
+
+        // Klassen Listener
+        const klassenRef = window.firebaseDB.ref(window.database, 'klassen');
+        activeListeners.klassen = window.firebaseDB.onValue(klassenRef, (snapshot) => {
+            if (snapshot.exists()) {
+                dataCache.klassen = Object.values(snapshot.val());
+                console.log('🔄 Klassen Update erhalten');
+                if (typeof updateKlassenSelects === 'function') {
+                    updateKlassenSelects();
+                }
+                if (typeof loadKlassenListe === 'function') {
+                    loadKlassenListe();
+                }
+                if (typeof updateKlassenauswahlForGruppen === 'function') {
+                    updateKlassenauswahlForGruppen();
+                }
+            }
+        });
+
+        // Benutzer Listener
+        const usersRef = window.firebaseDB.ref(window.database, 'users');
+        activeListeners.users = window.firebaseDB.onValue(usersRef, (snapshot) => {
+            if (snapshot.exists()) {
+                dataCache.users = snapshot.val();
+                console.log('🔄 Benutzer Update erhalten');
+                if (typeof updateLehrerSelects === 'function') {
+                    updateLehrerSelects();
                 }
             }
         });
@@ -431,6 +508,9 @@ function cleanupListeners() {
 
 // Tab Navigation
 function openTab(tabName, evt) {
+    if (tabName === 'klassen' && !window.firebaseFunctions.requireAdmin()) {
+        return;
+    }
     const contents = document.querySelectorAll('.tab-content');
     const buttons = document.querySelectorAll('.tab-btn');
 
@@ -462,6 +542,7 @@ function openTab(tabName, evt) {
         if (tabName === 'vorlagen') loadVorlagen();
         if (tabName === 'uebersicht') loadUebersicht();
         if (tabName === 'adminvorlagen') loadAdminVorlagen();
+        if (tabName === 'klassen') loadKlassen();
     } catch (error) {
         console.error('❌ Fehler beim Laden von Tab:', tabName, error);
     }
@@ -511,6 +592,16 @@ function getGruppenFromCache() {
     return Object.values(dataCache.gruppen || {});
 }
 
+// Klassen aus Cache
+function getKlassenFromCache() {
+    return Array.isArray(dataCache.klassen) ? dataCache.klassen : [];
+}
+
+// Lehrer aus Cache
+function getLehrerFromCache() {
+    return Object.values(dataCache.users || {}).filter(u => u.role === 'lehrer');
+}
+
 // Bewertungen aus Cache (für aktuellen Lehrer)
 function getBewertungenFromCache() {
     if (!currentUser) return [];
@@ -552,6 +643,8 @@ window.firebaseFunctions = {
     getNewsFromCache,
     getThemenFromCache,
     getGruppenFromCache,
+    getKlassenFromCache,
+    getLehrerFromCache,
     getBewertungenFromCache,
     getAllFaecher,
     getFachNameFromGlobal,

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
                 <button class="tab-btn active" onclick="openTab('news')" id="newsTab">News</button>
                 <button class="tab-btn" onclick="openTab('themen')" id="themenTab">Themen</button>
                 <button class="tab-btn" onclick="openTab('gruppen')" id="gruppenTab">Gruppen erstellen</button>
-                <button class="tab-btn" onclick="openTab('klassen')" id="klassenTab">Klassen verwalten</button>
+                <button class="tab-btn" onclick="openTab('klassen')" id="klassenTab" style="display:none;">Klassen verwalten</button>
                 <button class="tab-btn" onclick="openTab('lehrer')" id="lehrerTab">Lehrer verwalten</button>
                 <button class="tab-btn" onclick="openTab('daten')" id="datenTab">Datenverwaltung</button>
                 <button class="tab-btn" onclick="openTab('bewerten')" id="bewertenTab">Schüler bewerten</button>
@@ -231,32 +231,35 @@
                 <h2>Gruppen erstellen</h2>
                 <div class="card">
                     <h3>Neue Gruppe anlegen</h3>
-                    <div class="input-group">
-                        <input type="text" id="gruppenThema" placeholder="Thema (oder aus Liste wählen)">
-                        <button class="btn" onclick="gruppeErstellen()">Gruppe erstellen</button>
-                    </div>
-                    
-                    <div style="margin-top: 1rem;">
-                        <h4>1. Klasse auswählen:</h4>
-                        <select id="gruppenKlasseSelect" onchange="klasseGewaehlt()" style="width: 100%; padding: 10px; margin-bottom: 20px;">
-                            <option value="">Klasse auswählen...</option>
-                            <!-- Klassen werden dynamisch geladen -->
-                        </select>
-                        
-                        <h4>2. Schüler auswählen:</h4>
-                        <div id="verfuegbareSchueler">
-                            <p>Bitte wählen Sie eine Klasse aus.</p>
-                        </div>
-                        
-                        <h4>3. Lehrer und Fächer zuweisen:</h4>
-                        <div id="ausgewaehlteSchuelerAnzeige">
-                            <p>Keine Schüler ausgewählt.</p>
-                        </div>
-                    </div>
+                    <button class="btn btn-success" onclick="showGruppenCreateModal()">Neue Gruppe anlegen</button>
                 </div>
-                
+
                 <div class="liste" id="gruppenListe">
                     <!-- Gruppen werden hier angezeigt -->
+                </div>
+
+                <!-- Gruppen erstellen Modal -->
+                <div id="gruppenCreateModal" class="modal hidden">
+                    <div class="modal-content">
+                        <h3>Neue Gruppe anlegen</h3>
+                        <div class="input-group">
+                            <label>Titel:</label>
+                            <input type="text" id="gruppenThema">
+                        </div>
+                        <h4>1. Klasse auswählen:</h4>
+                        <select id="gruppenKlasseSelect" onchange="klasseGewaehlt()" style="width:100%; margin-bottom:10px;">
+                            <option value="">Klasse auswählen...</option>
+                        </select>
+                        <h4>2. Schüler auswählen:</h4>
+                        <div id="verfuegbareSchueler"><p>Bitte wählen Sie eine Klasse aus.</p></div>
+                        <div id="schuelerDetail"></div>
+                        <h4>3. Gewählte Schüler:</h4>
+                        <div id="ausgewaehlteSchuelerAnzeige"><p>Keine Schüler ausgewählt.</p></div>
+                        <div class="modal-buttons">
+                            <button class="btn btn-success" onclick="gruppeErstellenAbschliessen()">Gruppe abschließen</button>
+                            <button class="btn btn-danger" onclick="gruppeCreateAbbrechen()">Abbrechen</button>
+                        </div>
+                    </div>
                 </div>
                 
                 <!-- Gruppen bearbeiten Modal -->


### PR DESCRIPTION
## Summary
- hide the Klassen tab by default
- display Klassen tab only for admins
- protect `openTab('klassen')` with an admin check and load classes
- add modal-driven group creation flow with dynamic teacher list
- fetch teacher data from Firebase and refresh selects automatically

## Testing
- `node --check firebase-main.js`
- `node --check firebase-gruppen.js`
- `node --check firebase-auth.js`


------
https://chatgpt.com/codex/tasks/task_e_684345860588832cabf5061445619719