### PR TITLE
Add group creation permission control

### DIFF
--- a/firebase-admin.js
+++ b/firebase-admin.js
@@ -526,11 +526,16 @@ async function loadLehrerListe() {
             
             Object.entries(users).forEach(([key, user]) => {
                 if (user.role === 'lehrer') {
+                    const checked = user.kannGruppenAnlegen !== false ? 'checked' : '';
                     html += `
                         <div class="liste-item">
                             <div>
                                 <strong>${user.name}</strong><br>
-                                <small>E-Mail: ${user.email}</small>
+                                <small>E-Mail: ${user.email}</small><br>
+                                <label style="display:block;margin-top:4px;">
+                                    <input type="checkbox" ${checked} onchange="setLehrerGruppenErlaubnis('${key}', this.checked)">
+                                    Neue Gruppen anlegen
+                                </label>
                             </div>
                             <div>
                                 <button class="btn btn-danger" onclick="lehrerLoeschen('${key}', '${user.name}')">Löschen</button>

--- a/firebase-auth.js
+++ b/firebase-auth.js
@@ -273,6 +273,15 @@ function isLehrer() {
     return currentUser && currentUser.role === 'lehrer';
 }
 
+function canCreateGroups() {
+    if (!currentUser) return false;
+    if (currentUser.role === 'admin') return true;
+    if (currentUser.role === 'lehrer') {
+        return currentUser.kannGruppenAnlegen !== false;
+    }
+    return false;
+}
+
 function getCurrentUserName() {
     return currentUser ? currentUser.name : 'Unbekannt';
 }
@@ -331,6 +340,7 @@ window.authFunctions = {
     requireAdmin,
     isAdmin,
     isLehrer,
+    canCreateGroups,
     getCurrentUserName,
     getUserUid,
     getUserEmail,

--- a/firebase-datenverwaltung.js
+++ b/firebase-datenverwaltung.js
@@ -428,6 +428,7 @@ async function lehrerHinzufuegen() {
             name,
             email,
             role: 'lehrer',
+            kannGruppenAnlegen: true,
             erstellt: window.firebaseFunctions.formatGermanDate(),
             timestamp: window.firebaseFunctions.getTimestamp()
         });
@@ -524,13 +525,28 @@ async function lehrerLoeschen(userKey, lehrerName) {
     }
 }
 
+// Berechtigung zum Anlegen von Gruppen setzen
+async function setLehrerGruppenErlaubnis(userKey, erlaubt) {
+    if (!window.firebaseFunctions.requireAdmin()) return;
+
+    try {
+        const erlaubnisRef = window.firebaseFunctions.getDatabaseRef(`users/${userKey}/kannGruppenAnlegen`);
+        await window.firebaseDB.set(erlaubnisRef, erlaubt);
+        console.log('✅ Gruppenberechtigung aktualisiert für', userKey, '->', erlaubt);
+    } catch (error) {
+        console.error('❌ Fehler beim Aktualisieren der Gruppenberechtigung:', error);
+        alert('Fehler beim Aktualisieren der Gruppenberechtigung: ' + error.message);
+    }
+}
+
 // Export für andere Module
 window.datenverwaltungFunctions = {
     loadStatistiken,
     datenExportieren,
     datenLoeschen,
     lehrerHinzufuegen,
-    lehrerLoeschen
+    lehrerLoeschen,
+    setLehrerGruppenErlaubnis
 };
 
 console.log('✅ Firebase Datenverwaltung bereit');

--- a/firebase-gruppen.js
+++ b/firebase-gruppen.js
@@ -8,8 +8,13 @@ let ausgewaehlteSchueler = [];
 // Gruppen laden und anzeigen
 function loadGruppen() {
     console.log('👥 Lade Gruppen von Firebase...');
-    
+
     if (!window.firebaseFunctions.requireAuth()) return;
+
+    const createCard = document.getElementById('gruppenCreateCard');
+    if (createCard) {
+        createCard.style.display = window.firebaseFunctions.canCreateGroups() ? 'block' : 'none';
+    }
     
     const liste = document.getElementById('gruppenListe');
     if (!liste) return;
@@ -325,8 +330,13 @@ function ausgewaehltenSchuelerEntfernen(index) {
 // Neue Gruppe erstellen
 async function gruppeErstellen() {
     console.log('👥 Erstelle neue Gruppe...');
-    
+
     if (!window.firebaseFunctions.requireAuth()) return;
+
+    if (!window.firebaseFunctions.canCreateGroups()) {
+        alert('Sie haben keine Berechtigung, neue Gruppen anzulegen.');
+        return;
+    }
     
     const themaInput = document.getElementById('gruppenThema');
     const thema = themaInput?.value.trim();

--- a/firebase-main.js
+++ b/firebase-main.js
@@ -618,6 +618,7 @@ window.firebaseFunctions = {
     requireAdmin: () => window.authFunctions.requireAdmin(),
     isAdmin: () => window.authFunctions.isAdmin(),
     getCurrentUserName: () => window.authFunctions.getCurrentUserName(),
+    canCreateGroups: () => window.authFunctions.canCreateGroups(),
     
     // Firebase References
     getDatabase: () => window.database,

--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
             <!-- Gruppen Tab -->
             <div id="gruppen" class="tab-content">
                 <h2>Gruppen erstellen</h2>
-                <div class="card">
+                <div class="card" id="gruppenCreateCard">
                     <h3>Neue Gruppe anlegen</h3>
                     <div class="input-group">
                         <input type="text" id="gruppenThema" placeholder="Thema (oder aus Liste wählen)">


### PR DESCRIPTION
## Summary
- allow admins to toggle if a teacher can create new groups
- hide group creation UI when permission is disabled
- respect permission in group creation workflow

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_6843f1ad4720832caceb5f1a2e6716d4