### PR TITLE
Fix group creation toggle UI

### DIFF
--- a/firebase-gruppen.js
+++ b/firebase-gruppen.js
@@ -132,13 +132,21 @@ function showGruppenAnlegenUI(berechtigt) {
         });
         
         if (gruppenAnlegenCard) {
-            // Toggle-Button holen
-            const toggleBtn = document.getElementById('gruppenToggleBtn');
+            // Container für den Toggle holen
+            const toggleContainer = document.getElementById('gruppenToggleContainer');
 
             if (berechtigt) {
-                // Zeige normale UI
-                gruppenAnlegenCard.style.display = 'block';
-                if (toggleBtn) toggleBtn.style.display = '';
+                // Bereich initial eingeklappt lassen
+                gruppenAnlegenCard.style.display = 'none';
+                if (toggleContainer) toggleContainer.style.display = 'flex';
+
+                // Toggle zurücksetzen
+                const toggle = document.getElementById('gruppenErstellungToggle');
+                if (toggle) toggle.checked = false;
+
+                // Sicherstellen, dass Bereich geschlossen ist
+                const bereich = document.getElementById('gruppenErstellungBereich');
+                if (bereich) bereich.classList.remove('active');
 
                 // Eventuellen Hinweis entfernen
                 const hinweis = document.getElementById('keineGruppenBerechtigung');
@@ -148,10 +156,10 @@ function showGruppenAnlegenUI(berechtigt) {
             } else {
                 // Verstecke UI und Toggle-Button
                 gruppenAnlegenCard.style.display = 'none';
-                if (toggleBtn) toggleBtn.style.display = 'none';
+                if (toggleContainer) toggleContainer.style.display = 'none';
 
                 // Bereich sicher schließen
-                const bereich = document.getElementById('gruppenErstellenBereich');
+                const bereich = document.getElementById('gruppenErstellungBereich');
                 if (bereich) bereich.classList.remove('active');
 
                 // Hinweis entfernen, falls vorhanden

--- a/index.html
+++ b/index.html
@@ -170,12 +170,14 @@
         }
 
         .gruppenerstellung-bereich {
+            display: none;
             transition: all 0.3s ease;
             opacity: 0.5;
             pointer-events: none;
         }
 
         .gruppenerstellung-bereich.active {
+            display: block;
             opacity: 1;
             pointer-events: auto;
         }
@@ -716,11 +718,13 @@
         function toggleGruppenerstellung() {
             const toggle = document.getElementById('gruppenErstellungToggle');
             const bereich = document.getElementById('gruppenErstellungBereich');
-            
+
             if (toggle.checked) {
-                bereich.classList.add('active'); // Macht den Bereich sichtbar und interaktiv
+                bereich.classList.add('active'); // Bereich erscheint
+                bereich.style.display = 'block';
             } else {
-                bereich.classList.remove('active'); // Macht den Bereich halb-transparent und nicht interaktiv
+                bereich.classList.remove('active'); // Bereich wird ausgeblendet
+                bereich.style.display = 'none';
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure group creation UI uses correct element IDs
- show group creation section only when toggle is active

## Testing
- `node --check firebase-gruppen.js`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6846063ace60832c982271f345f29c17